### PR TITLE
Shout more warnings when requested JDK is not supported

### DIFF
--- a/jdk_switcher.sh
+++ b/jdk_switcher.sh
@@ -86,11 +86,11 @@ print_home_of_oraclejdk8 () {
 }
 
 warn_sunjdk6_eol () {
-    echo "Sun/Oracle JDK 6 is EOL since November 2012, and thus no more supported. Please consider upgrading..." >&2
+    echo "Sun/Oracle JDK 6 is EOL since November 2012, and is no longer supported. Please consider upgrading..." >&2
 }
 
-warn_jdk_not_found () {
-    echo "Sorry, but JDK '$1' is not known here." >&2
+warn_jdk_not_known () {
+    echo "Sorry, but JDK '$1' is not known." >&2
 }
 
 warn_gcj_user () {
@@ -124,7 +124,7 @@ switch_jdk()
             switch_to_oraclejdk7
             ;;
         *)
-            warn_jdk_not_found "$1"
+            warn_jdk_not_known "$1"
             false
             ;;
     esac
@@ -159,7 +159,7 @@ print_java_home()
             print_home_of_openjdk7
             ;;
         *)
-            warn_jdk_not_found "$JDK"
+            warn_jdk_not_known "$JDK"
             ;;
     esac
 }


### PR DESCRIPTION
Related to travis-ci/travis-ci#1291 and travis-cookbooks#236.

Note: `warn_sunjdk6_eol` is extra sugar, only `warn_jdk_not_found` matters. (By the way, I now realize that `warn_jdk_not_supported` may sound better...)

Possible future improvements: dynamically list the java alternatives and auto-support them if not listed in case list.
