### PR TITLE
Updated to include IBM Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ a command and the JDK to use:
 jdk_switcher  use openjdk7
 
 jdk_switcher home oraclejdk7
+
+jdk_switcher home ibmjdk8
 ```
 
 ### Commands
@@ -35,6 +37,8 @@ Supported aliases are:
  * `oraclejdk7` or `jdk7` or `default`
  * `openjdk7`
  * `openjdk6` or `jdk6`
+ * `ibmjava8` or `ibmjdk8`
+ * `ibmjava9` or `ibmjdk9`
 
 Sun JDK 6 will be EOL in November 2012 and is not supported. Ubuntu 12.04 and next Fedora release
 both will use OpenJDK 7 by default. Time to upgrade, JDK 7 is backwards compatible and packed with

--- a/jdk_switcher.sh
+++ b/jdk_switcher.sh
@@ -51,6 +51,20 @@ if [[ -d "/usr/lib/jvm/java-9-oracle-${ARCH_SUFFIX}" ]]; then
     ORACLEJDK9_JAVA_HOME="/usr/lib/jvm/java-9-oracle-${ARCH_SUFFIX}"
 fi
 
+IBMJAVA8_UJA_ALIAS="java-8-ibm"
+IBMJAVA8_JAVA_HOME="/usr/lib/jvm/java-8-ibm"
+if [[ -d "/usr/lib/jvm/java-8-ibm-${ARCH_SUFFIX}" ]]; then
+    IBMJAVA8_UJA_ALIAS="java-8-ibm-${ARCH_SUFFIX}"
+    IBMJAVA8_JAVA_HOME="/usr/lib/jvm/java-8-ibm-${ARCH_SUFFIX}"
+fi
+
+IBMJAVA9_UJA_ALIAS="java-9-ibm"
+IBMJAVA9_JAVA_HOME="/usr/lib/jvm/java-9-ibm"
+if [[ -d "/usr/lib/jvm/java-9-ibm-${ARCH_SUFFIX}" ]]; then
+    IBMJAVA9_UJA_ALIAS="java-9-ibm-${ARCH_SUFFIX}"
+    IBMJAVA9_JAVA_HOME="/usr/lib/jvm/java-9-ibm-${ARCH_SUFFIX}"
+fi
+
 for config_file in /etc/default/jdk-switcher "${HOME}/.jdk_switcherrc" "${JDK_SWITCHER_CONFIG}"; do
     if [[ -f "${config_file}" ]]; then
         # shellcheck source=/dev/null
@@ -94,6 +108,18 @@ switch_to_oraclejdk9() {
     export JAVA_HOME="$ORACLEJDK9_JAVA_HOME"
 }
 
+switch_to_ibmjava8() {
+    echo "Switching to IBM JAVA8 ($IBMJAVA8_UJA_ALIAS), JAVA_HOME will be set to $IBMJAVA8_JAVA_HOME"
+    sudo "${UJA}" --set "$IBMJAVA8_UJA_ALIAS"
+    export JAVA_HOME="$IBMJAVA8_JAVA_HOME"
+}
+
+switch_to_ibmjava9() {
+    echo "Switching to IBM JAVA9 ($IBMJAVA9_UJA_ALIAS), JAVA_HOME will be set to $IBMJAVA9_JAVA_HOME"
+    sudo "${UJA}" --set "$IBMJAVA9_UJA_ALIAS"
+    export JAVA_HOME="$IBMJAVA9_JAVA_HOME"
+}
+
 print_home_of_openjdk6() {
     echo "$OPENJDK6_JAVA_HOME"
 }
@@ -116,6 +142,14 @@ print_home_of_oraclejdk8() {
 
 print_home_of_oraclejdk9() {
     echo "$ORACLEJDK9_JAVA_HOME"
+}
+
+print_home_of_ibmjava8() {
+    echo "$IBMJAVA8_JAVA_HOME"
+}
+
+print_home_of_ibmjava9() {
+    echo "$IBMJAVA9_JAVA_HOME"
 }
 
 warn_sunjdk6_eol() {
@@ -158,6 +192,12 @@ switch_jdk() {
         oraclejdk9 | oraclejdk1.9 | oraclejdk1.9.0 | oracle9 | oracle1.9.0 | oracle9.0)
             switch_to_oraclejdk9
             ;;
+        ibmjava8 | ibmjava1.8 | ibmjava1.8.0 | ibmjdk8 | ibmjdk1.8 | ibmjdk1.8.0 | ibm8 | ibm1.8.0 | ibm8.0)
+            switch_to_ibmjava8
+            ;;
+        ibmjava9 | ibmjava1.9 | ibmjava1.9.0 | ibmjdk9 | ibmjdk1.9 | ibmjdk1.9.0 | ibm9 | ibm1.9.0 | ibm9.0)
+            switch_to_ibmjava9
+            ;;
         default)
             "switch_to_${JDK_SWITCHER_DEFAULT}"
             ;;
@@ -196,6 +236,12 @@ print_java_home() {
             ;;
         oraclejdk9 | oraclejdk1.9 | oraclejdk1.9.0 | oracle9 | oracle1.9.0 | oracle9.0)
             print_home_of_oraclejdk9
+            ;;
+        ibmjava8 | ibmjava1.8 | ibmjava1.8.0 | ibmjdk8 | ibmjdk1.8 | ibmjdk1.8.0 | ibm8 | ibm1.8.0 | ibm8.0)
+            print_home_of_ibmjava8
+            ;;
+        ibmjava9 | ibmjava1.9 | ibmjava1.9.0 | ibmjdk9 | ibmjdk1.9 | ibmjdk1.9.0 | ibm9 | ibm1.9.0 | ibm9.0)
+            print_home_of_ibmjava9
             ;;
         default)
             "print_home_of_${JDK_SWITCHER_DEFAULT}"


### PR DESCRIPTION
Hi, 

I have created a PR to make IBM Java8 and Java9 builds available on Travis. I have updated the jdk_switcher.sh to include changes for IBM Java.  Test runs on travis failed - https://travis-ci.org/chandrams/jdk_switcher

But when I tried this manually on a linux machine it worked fine for me.  Can please review and let me know if any changes are required. Thanks.

https://github.com/travis-ci/travis-cookbooks/pull/874